### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,17 @@ cp -v predidx-* ~/lib/sbcl/predidx
 cp -v src/predidx.qlf ~/lib/sbcl/
 ```
 
+Update the swipl config file:
+
+- SWI-Prolog version < 8.1.15<br>
 (add the following to ~/.swiplrc)
 ```sh
 echo ":- assertz(file_search_path(sbcl,'${HOME}/lib/sbcl'))." >> ${HOME}/.swiplrc
+```
+- SWI-Prolog version >= 8.1.15<br>
+run the following from the terminal
+```sh
+echo ":- assertz(file_search_path(sbcl,'${HOME}/lib/sbcl'))." >> ${HOME}/.config/swi-prolog/init.pl
 ```
 
 ## Description


### PR DESCRIPTION
While installing this on my System (MacOS Catalina, 10.15.7) I had the issue:
`source_sink `sbcl(predidx)' does not exist`
I installed swipl through brew.

It seems that the swipl config file moved as noted here:
https://www.swi-prolog.org/modified/config-files.html

This small PR updates the documentation for this.